### PR TITLE
src/driver_alsa.c: Backports of issue fixes observed when porting code to EDuke32.

### DIFF
--- a/src/driver_alsa.h
+++ b/src/driver_alsa.h
@@ -29,3 +29,5 @@ unsigned int ALSADrv_MIDI_GetTick(void);
 void ALSADrv_MIDI_SetTempo(int tempo, int division);
 void ALSADrv_MIDI_Lock(void);
 void ALSADrv_MIDI_Unlock(void);
+void ALSADrv_MIDI_QueueStart(void);
+void ALSADrv_MIDI_QueueStop(void);


### PR DESCRIPTION
Hi There,

Firstly, hello from Gosford NSW!

I was porting over your driver_alsa.c/h code into EDuke32's version of jfaudiolib for the purpose of direct MIDI playback and had a few issues that required correction, thought I'd pass them back.

If your code is merely just a backend for FluidSynth or something else, these issues might be a non-event, but at least with real MIDI hardware, I needed these changes to properly halt output of previous MIDI tracks before starting the next.

Scope of changes:

- Consolidate queue start/stop code into functions.
- Always drop output when stopping the queue.
- Ensure snd_seq_sync_output_queue(seq) is called after every time the queue is start/stopped and drained/dropped.

These changes, while tested for what I was working on for EDuke32, are untested in the scope of JFAudioLib on Linux. I feel this code might be a WIP for your project in any case given the hard-coded MIDI port of 128:0, etc.

Cheers,
Mitch.