### PR TITLE
Add a function to get the frequency of voices

### DIFF
--- a/include/fx_man.h
+++ b/include/fx_man.h
@@ -75,6 +75,7 @@ int FX_EndLooping( int handle );
 int FX_SetPan( int handle, int vol, int left, int right );
 int FX_SetPitch( int handle, int pitchoffset );
 int FX_SetFrequency( int handle, int frequency );
+int FX_GetFrequency( int handle, int *frequency );
 
 int FX_PlayVOC( char *ptr, unsigned int ptrlength, int pitchoffset, int vol, int left, int right,
        int priority, unsigned int callbackval );

--- a/src/fx_man.c
+++ b/src/fx_man.c
@@ -503,6 +503,32 @@ int FX_SetFrequency
 
 
 /*---------------------------------------------------------------------
+   Function: FX_GetFrequency
+
+   Gets the frequency of the voice associated with the specified handle.
+---------------------------------------------------------------------*/
+
+int FX_GetFrequency
+   (
+   int handle,
+   int *frequency
+   )
+
+   {
+   int status;
+
+   status = MV_GetFrequency( handle, frequency );
+   if ( status == MV_Error )
+      {
+      FX_SetErrorCode( FX_MultiVocError );
+      status = FX_Warning;
+      }
+
+   return( status );
+   }
+
+
+/*---------------------------------------------------------------------
    Function: FX_PlayVOC
 
    Begin playback of sound data with the given volume and priority.

--- a/src/multivoc.c
+++ b/src/multivoc.c
@@ -1393,6 +1393,45 @@ int MV_SetFrequency
 
 
 /*---------------------------------------------------------------------
+   Function: MV_GetFrequency
+
+   Gets the frequency for the voice associated with the specified handle.
+---------------------------------------------------------------------*/
+
+int MV_GetFrequency
+   (
+   int handle,
+   int *frequency
+   )
+
+   {
+   VoiceNode *voice;
+
+   if ( !MV_Installed )
+      {
+      MV_SetErrorCode( MV_NotInstalled );
+      return( MV_Error );
+      }
+
+   voice = MV_GetVoice( handle );
+   if ( voice == NULL )
+      {
+      MV_SetErrorCode( MV_VoiceNotFound );
+      return( MV_Error );
+      }
+
+    if ( voice->SamplingRate == 0 )
+      {
+      voice->GetSound( voice );
+      }
+
+   *frequency = voice->SamplingRate;
+
+   return( MV_Ok );
+   }
+
+
+/*---------------------------------------------------------------------
    Function: MV_GetVolumeTable
 
    Returns a pointer to the volume table associated with the specified

--- a/src/multivoc.h
+++ b/src/multivoc.h
@@ -63,6 +63,7 @@ int   MV_VoicesPlaying( void );
 int   MV_VoiceAvailable( int priority );
 int   MV_SetPitch( int handle, int pitchoffset );
 int   MV_SetFrequency( int handle, int frequency );
+int   MV_GetFrequency( int handle, int *frequency );
 int   MV_EndLooping( int handle );
 int   MV_SetPan( int handle, int vol, int left, int right );
 int   MV_Pan3D( int handle, int angle, int distance );


### PR DESCRIPTION
Added FX_GetFrequency and the implementation MV_GetFrequency to query the frequency of voices. This is useful for games that offset the sound frequency by fixed amounts instead of using pitches. 