### PR TITLE
Don't keep the frame pointer for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DXROOT ?= $(USERPROFILE)/sdks/directx/dx81
 ifeq (0,$(RELEASE))
  OPTLEVEL=-Og
 else
- OPTLEVEL=-O2
+ OPTLEVEL=-fomit-frame-pointer -O2
 endif
 
 CC?=gcc


### PR DESCRIPTION
Some platforms don't have this enabled by default, so I added `-fomit-frame-pointer` explicitly to the makefile. 